### PR TITLE
Update Skitch to 2.6.1. Also fixes broken URL.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class skitch {
   package { 'Skitch':
     provider => 'compressed_app',
-    source   => 'http://get.skitch.com/Skitch-2.5.2.zip'
+    source   => 'http://cdn1.evernote.com/skitch/mac/release/Skitch-2.6.1.zip'
   }
 }

--- a/spec/classes/skitch_spec.rb
+++ b/spec/classes/skitch_spec.rb
@@ -4,7 +4,7 @@ describe 'skitch' do
   it do
     should contain_package('Skitch').with(
       :provider => 'compressed_app',
-      :source   => 'http://get.skitch.com/Skitch-2.5.2.zip'
+      :source   => 'http://cdn1.evernote.com/skitch/mac/release/Skitch-2.6.1.zip'
     )
   end
 end


### PR DESCRIPTION
Current URL is returning a 403.
Updating to 2.6.1 and also the new URL.
